### PR TITLE
Integrate Cheshire with CFI snooper.

### DIFF
--- a/Bender.local
+++ b/Bender.local
@@ -3,17 +3,24 @@
 # SPDX-License-Identifier: SHL-0.51
 
 overrides:
-  axi:                  { git: "https://github.com/pulp-platform/axi.git"                 , version: 0.39.1                                 }
+  axi:                  { git: "https://github.com/pulp-platform/axi.git"                 , version: =0.39.8 }
   axi_riscv_atomics:    { git: "https://github.com/pulp-platform/axi_riscv_atomics.git"   , rev: 062bc36cbcca25629384e7f12efa6693273b3e07 } # branch: main
-  apb:                  { git: "https://github.com/pulp-platform/apb.git"                 , version: 0.2.3 }
-  tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.13                                }
-  riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.0                                 }
-  idma:                 { git: "https://github.com/pulp-platform/idma.git"                , version: 0.6.2 }
+  apb:                  { git: "https://github.com/pulp-platform/apb.git"                 , version: =0.2.4 }
+  tech_cells_generic:   { git: "https://github.com/pulp-platform/tech_cells_generic.git"  , version: =0.2.13 }
+  riscv-dbg:            { git: "https://github.com/pulp-platform/riscv-dbg.git"           , version: =0.8.1 }
+  idma:                 { git: "https://github.com/pulp-platform/idma.git"                , version: =0.6.5 }
   fpnew:                { git: "https://github.com/FondazioneChipsIT/cvfpu.git"           , rev: 49b1cb4d50893a9d23f8329d857527ebe5bc8529 } # branch: yt/pulp-merge-v2
-  cv32e40p:             { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991   }
-  axi_rt:               { git: "https://github.com/pulp-platform/axi_rt.git"              , version: =0.0.0-alpha.8                         }
-  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: "9e31f7c6c24877eaf58279903e7a162b16c9a721" } # branch: astral-v0
-  register_interface:   { git: "https://github.com/pulp-platform/register_interface.git"  , version: 0.4.4                                  }
-  common_cells:         { git: "https://github.com/pulp-platform/common_cells.git"        , version: 1.37.0                                 } # branch: master
-  riscv-iommu:          { git: "https://github.com/zero-day-labs/riscv-iommu.git"         , rev: c1dea3732d0d05e5659b31773e43f3364bc866fc   } # branch: pulp
-  axi_obi:              { git: "https://github.com/pulp-platform/axi_obi.git"             , rev: 84f21a6524bedcf17a569a62ac01b8a5610819c8   } # branch: main
+  cv32e40p:             { git: "https://github.com/pulp-platform/cv32e40p.git"            , rev: e863f576699815b38cc9d80dbdede8ed5efd5991 }
+  axi_rt:               { git: "https://github.com/pulp-platform/axi_rt.git"              , version: =0.0.0-alpha.10 }
+  redundancy_cells:     { git: "https://github.com/pulp-platform/redundancy_cells.git"    , rev: 9e31f7c6c24877eaf58279903e7a162b16c9a721 } # branch: astral-v0
+  register_interface:   { git: "https://github.com/pulp-platform/register_interface.git"  , version: =0.4.7 }
+  common_cells:         { git: "https://github.com/pulp-platform/common_cells.git"        , version: =1.38.0 }
+  riscv-iommu:          { git: "https://github.com/zero-day-labs/riscv-iommu.git"         , rev: c1dea3732d0d05e5659b31773e43f3364bc866fc } # branch: pulp
+  axi_obi:              { git: "https://github.com/pulp-platform/axi_obi.git"             , rev: 84f21a6524bedcf17a569a62ac01b8a5610819c8 } # branch: main
+  clic:                 { git: "https://github.com/pulp-platform/clic.git"                , version: =3.0.0 }
+  obi:                  { git: "https://github.com/pulp-platform/obi.git"                 , version: =0.1.7 }
+  cluster_interconnect: { git: "https://github.com/pulp-platform/cluster_interconnect.git", version: =1.3.0 }
+  scm:                  { git: "https://github.com/pulp-platform/scm.git"                 , version: =1.2.0 }
+  hci:                  { git: "https://github.com/pulp-platform/hci.git"                 , rev: 2a5a5081a2b32f1a04e7e28c00d3762d92602b84 }
+  hwpe-stream:          { git: "https://github.com/pulp-platform/hwpe-stream.git"         , version: =1.9.0 }
+  hwpe-ctrl:            { git: "https://github.com/pulp-platform/hwpe-ctrl.git"           , version: =2.0.0 }

--- a/Bender.lock
+++ b/Bender.lock
@@ -115,7 +115,7 @@ packages:
       Git: https://github.com/AlSaqr-platform/can_bus.git
     dependencies: []
   cheshire:
-    revision: d8684b41a375e33e92c21eb2075d232c0ea44438
+    revision: b975fe3b71358c95205f53f86e27512ac37729c1
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/cheshire.git
@@ -138,6 +138,7 @@ packages:
     - register_interface
     - riscv-dbg
     - serial_link
+    - snooper
     - unbent
   clic:
     revision: 6515a71eb4ae3b143ab912d265e79832b3179a76
@@ -209,7 +210,7 @@ packages:
       Git: https://github.com/pulp-platform/cv32e40x.git
     dependencies: []
   cva6:
-    revision: 9ff9791eb7b54540c0f03660149ab9a6ac76e022
+    revision: 67464fc118a8da941478584e55751b69f4a6823c
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/cva6.git
@@ -549,6 +550,16 @@ packages:
     - axi
     - common_cells
     - register_interface
+  snooper:
+    revision: 9acbfe6b0e29148100aea08a9f052486d5e74033
+    version: null
+    source:
+      Git: https://github.com/FondazioneChipsIT/cfi-snooper.git
+    dependencies:
+    - axi
+    - common_cells
+    - register_interface
+    - tcdm_interconnect
   softex:
     revision: 11dd29e85d40e29fea0481b471f1c0cc967df1a4
     version: null
@@ -575,6 +586,13 @@ packages:
     - register_interface
     - riscv-dbg
     - tech_cells_generic
+  tcdm_interconnect:
+    revision: 7d0a4f8acae71a583a6713cab5554e60b9bb8d27
+    version: 1.2.1
+    source:
+      Git: https://github.com/pulp-platform/cluster_interconnect.git
+    dependencies:
+    - common_cells
   tech_cells_generic:
     revision: 7968dd6e6180df2c644636bc6d2908a49f2190cf
     version: 0.2.13

--- a/Bender.lock
+++ b/Bender.lock
@@ -24,8 +24,8 @@ packages:
     - obi_peripherals
     - register_interface
   axi:
-    revision: fccffb5953ec8564218ba05e20adbedec845e014
-    version: 0.39.1
+    revision: 78831b6feba265d5ee2683bbf42b4150f8a35c43
+    version: 0.39.8
     source:
       Git: https://github.com/pulp-platform/axi.git
     dependencies:
@@ -77,8 +77,8 @@ packages:
     - common_cells
     - common_verification
   axi_rt:
-    revision: d5f857e74d0a5db4e4a2cc3652ca4f40f29a1484
-    version: 0.0.0-alpha.8
+    revision: 50153a346b753dc2bc7723c446656a43db35d02d
+    version: 0.0.0-alpha.10
     source:
       Git: https://github.com/pulp-platform/axi_rt.git
     dependencies:
@@ -181,8 +181,8 @@ packages:
     dependencies:
     - hci
   common_cells:
-    revision: 9ca8a7655f741e7dd5736669a20a301325194c28
-    version: 1.39.0
+    revision: 9afda9abb565971649c2aa0985639c096f351171
+    version: 1.38.0
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:
@@ -506,8 +506,8 @@ packages:
     - common_cells
     - common_verification
   riscv-dbg:
-    revision: 138d74bcaa90c70180c12215db3776813d2a95f2
-    version: 0.8.0
+    revision: 358f90110220adf7a083f8b65d157e836d706236
+    version: 0.8.1
     source:
       Git: https://github.com/pulp-platform/riscv-dbg.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,7 +13,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.3                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
-  cheshire:           { git: https://github.com/FondazioneChipsIT/cheshire.git,         rev: d8684b41a375e33e92c21eb2075d232c0ea44438 } # branch: yt/cvfpu
+  cheshire:           { git: https://github.com/FondazioneChipsIT/cheshire.git,         rev: b975fe3b71358c95205f53f86e27512ac37729c1 } # branch: devel/scarv
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.9}
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: 584eb697195c44ef1b1cbd1f4b7accdf5192200a } # branch: main

--- a/hw/carfield_pkg.sv
+++ b/hw/carfield_pkg.sv
@@ -675,6 +675,7 @@ localparam cheshire_pkg::cheshire_cfg_t CarfieldCfgDefault = '{
   Clic              : 0,
   IrqRouter         : 1,
   BusErr            : 0,
+  Snooper           : 1,
   // HmrUnit           : 1,
   // Cva6DMR           : 1,
   // Cva6DMRFixed      : 0,


### PR DESCRIPTION
Bump Cheshire commit to fix CVA6 version.