### PR TITLE
[CI] Fix CI flow

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -13,7 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Gitlab CI
-        uses: pulp-platform/pulp-actions/gitlab-ci@v1
+        uses: pulp-platform/pulp-actions/gitlab-ci@v2.4.1
+        # Skip on forks or pull requests from forks due to missing secrets.
+        if: >
+          github.repository == 'FondazioneChipsIT/astral' &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           domain: gitlab.chips.it
           repo: digitalresearchline/githubmirrors/astral

--- a/carfield.mk
+++ b/carfield.mk
@@ -142,7 +142,7 @@ AXIRT_NUM_SUBS := 2
 # Virtual environment for python scripts #
 ##########################################
 
-VENVDIR?=$(WORKDIR)/.venv
+VENVDIR?=$(CAR_ROOT)/.venv
 REQUIREMENTS_TXT?=$(wildcard requirements.txt)
 include $(CAR_ROOT)/utils/venv.mk
 
@@ -181,7 +181,8 @@ include $(CAR_SW_DIR)/sw.mk
 ## Build the host domain (Cheshire) SW libraries and generates an archive (`libcheshire.a`)
 ## available for Carfield as static library at link time.
 CHS_SW_FLAGS += -Wno-int-conversion -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-implicit-int
-chs-sw-build: chs-sw-all
+chs-sw-build: | venv
+	. "$(VENV)/activate" && $(MAKE) chs-sw-all
 
 .PHONY: car-sw-build
 ## Builds carfield application SW and specific libraries. It links against `libcheshire.a`.
@@ -308,12 +309,12 @@ spatzd-hw-init:
 ## Generate Cheshire HW. This target has a prerequisite, i.e. the PLIC and serial link
 ## configurations must be chosen before generating the hardware.
 .PHONY: chs-hw-init
-chs-hw-init: update_plic update_serial_link
-	$(MAKE) -B chs-hw-all
+chs-hw-init: update_plic update_serial_link | venv
+	. "$(VENV)/activate" && $(MAKE) -B chs-hw-all
 
 .PHONY: idma-hw-init
-idma-hw-init:
-	$(MAKE) -C $(shell bender path idma) idma_hw_all
+idma-hw-init: | venv
+	. "$(VENV)/activate" && $(MAKE) -C $(shell bender path idma) idma_hw_all
 
 ##############
 # Simulation #

--- a/carfield.mk
+++ b/carfield.mk
@@ -411,7 +411,7 @@ car-check-litmus-tests: $(LITMUS_WORK_DIR)/litmus.log
 ##############
 tech-repo := git@gitlab.chips.it:digitalresearchline/scar-v/gf22.git
 # no commit by default, change during development
-tech-commit := 9a2ad6675525d98827b85b3e613dcfb5d3c3db63 # branch: adr/dev
+tech-commit := 9b9b70aed9877369eab68bb64c45fcceb62488ed # branch: main
 
 tech-clone:
 	git clone $(tech-repo) $(CAR_TECH_DIR)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ mkdocs-material
 mkdocs-glightbox
 pandas
 flatdict
+setuptools==53.0.0


### PR DESCRIPTION
This PR fixes the CI flow for the new target machine:

- Use `venv` for Python-related stuff, instead of relying on global/user-installed packages
- Update pulp-actions to v2.4.1 and skip creating pipelines on forks or pull requests from forks
- Bump closed-source `tech-repo` to main branch