### PR TITLE
[SW] Improve SECD software compile flow and extend test list

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -413,7 +413,7 @@ packages:
     - common_cells
     - obi
   opentitan:
-    revision: ec68699991adc33446f54581fba541f692c26de6
+    revision: d017bc599422ac5176e7b2827c8c2d74e0023d7d
     version: null
     source:
       Git: https://github.com/AlSaqr-platform/opentitan.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -124,7 +124,7 @@ packages:
       Git: https://github.com/AlSaqr-platform/can_bus.git
     dependencies: []
   cheshire:
-    revision: 54672da4ec7d001bf1c1a104eb70ef25a7e1f4db
+    revision: 77fa77e81c4d4dd93c7d96f6c161a79995c496fb
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/cheshire.git
@@ -413,7 +413,7 @@ packages:
     - common_cells
     - obi
   opentitan:
-    revision: 1f4a4525593fc6e9dbaf24561b3b2010de23e069
+    revision: c33baf15b2c93b19ae3ec776d6ccd66326ec9ef7
     version: null
     source:
       Git: https://github.com/AlSaqr-platform/opentitan.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -413,7 +413,7 @@ packages:
     - common_cells
     - obi
   opentitan:
-    revision: 1753078bf733aeda1da4e2a5252e21dd938aa410
+    revision: 1f4a4525593fc6e9dbaf24561b3b2010de23e069
     version: null
     source:
       Git: https://github.com/AlSaqr-platform/opentitan.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -124,7 +124,7 @@ packages:
       Git: https://github.com/AlSaqr-platform/can_bus.git
     dependencies: []
   cheshire:
-    revision: 77fa77e81c4d4dd93c7d96f6c161a79995c496fb
+    revision: e054df1d98ac9b9104bce3898a0d4d1913e4377b
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/cheshire.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -413,7 +413,7 @@ packages:
     - common_cells
     - obi
   opentitan:
-    revision: c33baf15b2c93b19ae3ec776d6ccd66326ec9ef7
+    revision: ec68699991adc33446f54581fba541f692c26de6
     version: null
     source:
       Git: https://github.com/AlSaqr-platform/opentitan.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,7 +13,7 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.3                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
-  cheshire:           { git: https://github.com/FondazioneChipsIT/cheshire.git,         rev: 77fa77e81c4d4dd93c7d96f6c161a79995c496fb } # branch: pr/plic-lib
+  cheshire:           { git: https://github.com/FondazioneChipsIT/cheshire.git,         rev: e054df1d98ac9b9104bce3898a0d4d1913e4377b } # branch: devel/scarv
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.9}
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: 584eb697195c44ef1b1cbd1f4b7accdf5192200a } # branch: main

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: 584eb697195c44ef1b1cbd1f4b7accdf5192200a } # branch: main
   pulp_cluster:       { git: https://github.com/FondazioneChipsIT/pulp_cluster.git,     rev: b2dd982cb829b5b280a651d3312a69e5b4e3c3f3 } # branch: security_island
-  opentitan:          { git: https://github.com/AlSaqr-platform/opentitan.git,          rev: 1753078bf733aeda1da4e2a5252e21dd938aa410 } # branch: chips-it
+  opentitan:          { git: https://github.com/AlSaqr-platform/opentitan.git,          rev: 1f4a4525593fc6e9dbaf24561b3b2010de23e069 } # branch: chips-it
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: =1.0.3                               }

--- a/Bender.yml
+++ b/Bender.yml
@@ -13,12 +13,12 @@ package:
 dependencies:
   register_interface: { git: https://github.com/pulp-platform/register_interface.git,   version: 0.4.3                                }
   axi:                { git: https://github.com/pulp-platform/axi.git,                  version: 0.39.1                               }
-  cheshire:           { git: https://github.com/FondazioneChipsIT/cheshire.git,         rev: 54672da4ec7d001bf1c1a104eb70ef25a7e1f4db } # branch: devel/scarv
+  cheshire:           { git: https://github.com/FondazioneChipsIT/cheshire.git,         rev: 77fa77e81c4d4dd93c7d96f6c161a79995c496fb } # branch: pr/plic-lib
   hyperbus:           { git: https://github.com/pulp-platform/hyperbus.git,             version: 0.0.9}
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: 584eb697195c44ef1b1cbd1f4b7accdf5192200a } # branch: main
   pulp_cluster:       { git: https://github.com/FondazioneChipsIT/pulp_cluster.git,     rev: b2dd982cb829b5b280a651d3312a69e5b4e3c3f3 } # branch: security_island
-  opentitan:          { git: https://github.com/AlSaqr-platform/opentitan.git,          rev: 1f4a4525593fc6e9dbaf24561b3b2010de23e069 } # branch: chips-it
+  opentitan:          { git: https://github.com/AlSaqr-platform/opentitan.git,          rev: c33baf15b2c93b19ae3ec776d6ccd66326ec9ef7 } # branch: chips-it
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: =1.0.3                               }

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: 584eb697195c44ef1b1cbd1f4b7accdf5192200a } # branch: main
   pulp_cluster:       { git: https://github.com/FondazioneChipsIT/pulp_cluster.git,     rev: b2dd982cb829b5b280a651d3312a69e5b4e3c3f3 } # branch: security_island
-  opentitan:          { git: https://github.com/AlSaqr-platform/opentitan.git,          rev: ec68699991adc33446f54581fba541f692c26de6 } # branch: pr/snooper-stress-test
+  opentitan:          { git: https://github.com/AlSaqr-platform/opentitan.git,          rev: d017bc599422ac5176e7b2827c8c2d74e0023d7d } # branch: chips-it
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: =1.0.3                               }

--- a/Bender.yml
+++ b/Bender.yml
@@ -18,7 +18,7 @@ dependencies:
   dyn_mem:            { git: https://github.com/pulp-platform/dyn_spm.git,              rev: 480590062742230dc9bd4050358a15b4747bdf34 } # branch: main
   safety_island:      { git: https://github.com/pulp-platform/safety_island.git,        rev: 584eb697195c44ef1b1cbd1f4b7accdf5192200a } # branch: main
   pulp_cluster:       { git: https://github.com/FondazioneChipsIT/pulp_cluster.git,     rev: b2dd982cb829b5b280a651d3312a69e5b4e3c3f3 } # branch: security_island
-  opentitan:          { git: https://github.com/AlSaqr-platform/opentitan.git,          rev: c33baf15b2c93b19ae3ec776d6ccd66326ec9ef7 } # branch: chips-it
+  opentitan:          { git: https://github.com/AlSaqr-platform/opentitan.git,          rev: ec68699991adc33446f54581fba541f692c26de6 } # branch: pr/snooper-stress-test
   mailbox_unit:       { git: https://github.com/pulp-platform/mailbox_unit.git,         version: 1.1.0                                }
   apb:                { git: https://github.com/pulp-platform/apb.git,                  version: 0.2.3                                }
   timer_unit:         { git: https://github.com/pulp-platform/timer_unit.git,           version: =1.0.3                               }

--- a/carfield.mk
+++ b/carfield.mk
@@ -52,7 +52,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@gitlab.chips.it:digitalresearchline/scar-v/nonfree.git
-CAR_NONFREE_COMMIT ?= 2c5a516c9da2bf5af811ce7ae8d325a2e8887a5a
+CAR_NONFREE_COMMIT ?= fdcc4f7effd592a1a4f27d664508b79abb68073d
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -52,7 +52,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@gitlab.chips.it:digitalresearchline/scar-v/nonfree.git
-CAR_NONFREE_COMMIT ?= 092b13770f4fe2a48df5fa2421c3bef49eca825f
+CAR_NONFREE_COMMIT ?= 2c5a516c9da2bf5af811ce7ae8d325a2e8887a5a
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/carfield.mk
+++ b/carfield.mk
@@ -52,7 +52,7 @@ include $(CAR_ROOT)/bender-safed.mk
 ######################
 
 CAR_NONFREE_REMOTE ?= git@gitlab.chips.it:digitalresearchline/scar-v/nonfree.git
-CAR_NONFREE_COMMIT ?= 16aeec4fcb269520149c56676ce4253983fe2168
+CAR_NONFREE_COMMIT ?= 092b13770f4fe2a48df5fa2421c3bef49eca825f
 
 ## @section Carfield platform nonfree components
 ## Clone the non-free verification IP for Carfield. Some components such as CI scripts and ASIC

--- a/sw/tests/bare-metal/hostd/mbox_test.c
+++ b/sw/tests/bare-metal/hostd/mbox_test.c
@@ -1,4 +1,4 @@
-// Copyright 2023 ETH Zurich and University of Bologna.
+// Copyright 2023 ETH Zurich, University of Bologna and and Fondazione Chips-IT.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -29,17 +29,13 @@
 
 int main(int argc, char const *argv[]) {
 
-    // Put SMP Hart to sleep
-    // if (hart_id() != 0) wfi();
-        // Init the HW (this also includes UART)
-    int err = 0;
-
+    // Init the HW (this also includes UART)
     car_init_start();
 
-    int a;
+    int mbox_msg;
     unsigned global_irq_en   = 0x00001808;
     unsigned external_irq_en = 0x00000800;
-    LOG("hello cheshire\n\r");
+    LOG("Hello cheshire\n\r");
 
     asm volatile("csrw  mstatus, %0\n" : : "r"(global_irq_en  ));     // Set global interrupt enable in CVA6 csr
     asm volatile("csrw  mie, %0\n"     : : "r"(external_irq_en));     // Set external interrupt enable in CVA6 csr
@@ -52,8 +48,8 @@ int main(int argc, char const *argv[]) {
         ;
 
     writew(0xBAADC0DE, MBOX_CAR_LETTER0(0x1));
-    a = readw(MBOX_CAR_LETTER0(1));
-    if( a == 0xBAADC0DE ) {
+    mbox_msg = readw(MBOX_CAR_LETTER0(1));
+    if (mbox_msg == 0xBAADC0DE) {
       writew(0x00000001, MBOX_CAR_INT_SND_SET(0x1)); // ring doorbell if mailbox is accessible
       writew(0x00000001, MBOX_CAR_INT_SND_EN(0x1));
     }

--- a/sw/tests/bare-metal/hostd/mbox_test.c
+++ b/sw/tests/bare-metal/hostd/mbox_test.c
@@ -15,26 +15,39 @@
 #include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include "car_util.h"
+#include "printf.h"
+
+#ifndef VERBOSE
+#define VERBOSE 0
+#endif
+#define LOG(fmt, ...) do { if (VERBOSE) printf(fmt, ##__VA_ARGS__); } while (0)
 
 static dif_rv_plic_t plic0;
 
-#define IRQID 69 // index of mbox irq in the irq vector input to the PLIC
+#define IRQID 64 // index of mbox irq in the irq vector input to the PLIC
+
+// Synchronization values (ibex -> CVA6 via CHESHIRE_SCRATCH_4)
+#define SYNC_IBEX_READY  0xa5a5a5a5  // ibex interrupt setup done, CVA6 may send mbox message
 
 int main(int argc, char const *argv[]) {
 
     // Put SMP Hart to sleep
     // if (hart_id() != 0) wfi();
+        // Init the HW (this also includes UART)
+    car_init_start();
 
     int prio = 0x1;
     int a,b,c,d,e;
     bool t;
     unsigned global_irq_en   = 0x00001808;
     unsigned external_irq_en = 0x00000800;
+    LOG("hello cheshire\n\r");
 
-    // Uart setup
-    uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
-    uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
-    uart_init(&__base_uart, reset_freq, 115200);
+    // // Uart setup
+    // uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
+    // uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
+    // uart_init(&__base_uart, reset_freq, 115200);
 
     asm volatile("csrw  mstatus, %0\n" : : "r"(global_irq_en  ));     // Set global interrupt enable in CVA6 csr
     asm volatile("csrw  mie, %0\n"     : : "r"(external_irq_en));     // Set external interrupt enable in CVA6 csr
@@ -46,21 +59,28 @@ int main(int argc, char const *argv[]) {
       t = dif_rv_plic_irq_set_priority(&plic0, IRQID+i*5, prio);
       t = dif_rv_plic_irq_set_enabled(&plic0, IRQID+i*5, 0, kDifToggleEnabled);
     }
-    writew(0xBAADC0DE, 0x40000280);
-    a = readw(0x40000280);
-    if( a == 0xBAADC0DE )
-      writew(0x00000001, 0x40000204); // ring doorbell if mailbox is accessible
-      writew(0x00000001, 0x4000020C);
+    // Wait for ibex to finish setting up its interrupt handler before sending
+    while (*reg32(&__base_regs, CHESHIRE_SCRATCH_4_REG_OFFSET) != (int)SYNC_IBEX_READY)
+        ;
+
+    writew(0xBAADC0DE, MBOX_CAR_LETTER0(0x1));
+    a = readw(MBOX_CAR_LETTER0(1));
+    if( a == 0xBAADC0DE ) {
+      writew(0x00000001, MBOX_CAR_INT_SND_SET(0x1)); // ring doorbell if mailbox is accessible
+      writew(0x00000001, MBOX_CAR_INT_SND_EN(0x1));
+    }
     wfi();
     return 0;
 }
 
 void trap_vector (void){
    int * claim_irq;
+   LOG("Interrupt catched");
    dif_rv_plic_irq_claim(&plic0, 0, &claim_irq);
    dif_rv_plic_irq_complete(&plic0, 0, &claim_irq);
-   writew(0x0, 0x40000D04);
-   writew(0x0, 0x40000D0C);
-   writew(0x1, 0x40000D08);
+   writew(0x0, MBOX_CAR_INT_SND_SET(0x7));
+   writew(0x0, MBOX_CAR_INT_SND_EN(0x7));
+   writew(0x1, MBOX_CAR_INT_SND_CLR(0x7));
+   LOG("[mbox_test] PASSED\n\r");
    return;
 }

--- a/sw/tests/bare-metal/hostd/mbox_test.c
+++ b/sw/tests/bare-metal/hostd/mbox_test.c
@@ -5,10 +5,15 @@
 // Maicol Ciani <maicol.ciani@unibo.it>
 //
 
+#ifndef VERBOSE
+#define VERBOSE 1
+#endif
+#define LOG(fmt, ...) do { if (VERBOSE) printf(fmt, ##__VA_ARGS__); } while (0)
+
 #include "car_memory_map.h"
 #include "io.h"
 #include "regs/cheshire.h"
-#include "sw/device/lib/dif/dif_rv_plic.h" // to be changed accoridng to correct hash
+#include "dif/rv_plic.h" // Cheshire/CVA6 PLIC driver
 #include "dif/clint.h"
 #include "dif/uart.h"
 #include "params.h"
@@ -18,15 +23,7 @@
 #include "car_util.h"
 #include "printf.h"
 
-#ifndef VERBOSE
-#define VERBOSE 0
-#endif
-#define LOG(fmt, ...) do { if (VERBOSE) printf(fmt, ##__VA_ARGS__); } while (0)
-
-static dif_rv_plic_t plic0;
-
-#define IRQID 64 // index of mbox irq in the irq vector input to the PLIC
-
+#define IRQID CHS_PLIC_IRQ_SECD_MBOX_HOSTD // security island -> hostd mailbox IRQ
 // Synchronization values (ibex -> CVA6 via CHESHIRE_SCRATCH_4)
 #define SYNC_IBEX_READY  0xa5a5a5a5  // ibex interrupt setup done, CVA6 may send mbox message
 
@@ -35,30 +32,21 @@ int main(int argc, char const *argv[]) {
     // Put SMP Hart to sleep
     // if (hart_id() != 0) wfi();
         // Init the HW (this also includes UART)
+    int err = 0;
+
     car_init_start();
 
-    int prio = 0x1;
-    int a,b,c,d,e;
-    bool t;
+    int a;
     unsigned global_irq_en   = 0x00001808;
     unsigned external_irq_en = 0x00000800;
     LOG("hello cheshire\n\r");
 
-    // // Uart setup
-    // uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
-    // uint64_t reset_freq = clint_get_core_freq(rtc_freq, 2500);
-    // uart_init(&__base_uart, reset_freq, 115200);
-
     asm volatile("csrw  mstatus, %0\n" : : "r"(global_irq_en  ));     // Set global interrupt enable in CVA6 csr
     asm volatile("csrw  mie, %0\n"     : : "r"(external_irq_en));     // Set external interrupt enable in CVA6 csr
-    // PLIC setup
-    mmio_region_t plic_base_addr = mmio_region_from_addr(&__base_plic);
-    t = dif_rv_plic_init(plic_base_addr, &plic0);
-    // Set two consecutive interrupts otherwise the SLINK breaks while loading the binary...
-    for (int i = 0; i < 2; i++) {
-      t = dif_rv_plic_irq_set_priority(&plic0, IRQID+i*5, prio);
-      t = dif_rv_plic_irq_set_enabled(&plic0, IRQID+i*5, 0, kDifToggleEnabled);
-    }
+
+    // PLIC setup via Cheshire PLIC driver
+    chs_plic_irq_set_priority(&__base_plic, IRQID, 1u);
+    chs_plic_irq_set_enabled (&__base_plic, IRQID, 0u, 1);
     // Wait for ibex to finish setting up its interrupt handler before sending
     while (*reg32(&__base_regs, CHESHIRE_SCRATCH_4_REG_OFFSET) != (int)SYNC_IBEX_READY)
         ;
@@ -74,13 +62,22 @@ int main(int argc, char const *argv[]) {
 }
 
 void trap_vector (void){
-   int * claim_irq;
-   LOG("Interrupt catched");
-   dif_rv_plic_irq_claim(&plic0, 0, &claim_irq);
-   dif_rv_plic_irq_complete(&plic0, 0, &claim_irq);
+   chs_plic_irq_id_t claimed_irq;
+   LOG("[mbox_test] trap_vector: interrupt fired\n\r");
+   chs_plic_irq_claim(&__base_plic, 0u, &claimed_irq);
+   if (claimed_irq != IRQID) {
+      LOG("[mbox_test] FAILED: unexpected IRQ %u (expected %u)\n\r",
+             (unsigned)claimed_irq, (unsigned)IRQID);
+      chs_plic_irq_complete(&__base_plic, 0u, claimed_irq);
+      return;
+   }
+   LOG("[mbox_test] claimed IRQ %u (expected %u) OK\n\r",
+       (unsigned)claimed_irq, (unsigned)IRQID);
+
    writew(0x0, MBOX_CAR_INT_SND_SET(0x7));
    writew(0x0, MBOX_CAR_INT_SND_EN(0x7));
    writew(0x1, MBOX_CAR_INT_SND_CLR(0x7));
+   chs_plic_irq_complete(&__base_plic, 0u,  claimed_irq);
    LOG("[mbox_test] PASSED\n\r");
    return;
 }

--- a/sw/tests/bare-metal/hostd/snooper_stress_test.c
+++ b/sw/tests/bare-metal/hostd/snooper_stress_test.c
@@ -1,229 +1,93 @@
-// Copyright 2023 ETH Zurich and University of Bologna.
+// Copyright 2024 ETH Zurich, University of Bologna and Fondazione Chips-IT.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "regs/cheshire.h"
-#include "dif/clint.h"
-#include "dif/uart.h"
-#include "params.h"
 #include "util.h"
-#include "regs/snooper_regs.h"
+#include "printf.h"
 #include "car_util.h"
 
-void set_register_bit(void *base_addr, uint32_t reg_offset, uint32_t bit_position) {
-    uint32_t reg_value = *reg32(base_addr, reg_offset);
-    reg_value |= (1 << bit_position);
-    *reg32(base_addr, reg_offset) = reg_value;
-}
+#ifndef VERBOSE
+#define VERBOSE 1
+#endif
+#define LOG(fmt, ...) do { if (VERBOSE) printf(fmt, ##__VA_ARGS__); } while (0)
 
-void clear_register_bit(void *base_addr, uint32_t reg_offset, uint32_t bit_position) {
-    uint32_t reg_value = *reg32(base_addr, reg_offset);
-    reg_value &= ~(1U << bit_position);
-    *reg32(base_addr, reg_offset) = reg_value;
-}
+// CVA6 -> ibex: written to CHESHIRE_SCRATCH_10
+#define SYNC_ADDR_VALID  0xdeadbeef  // addresses published, ibex can configure snooper
+#define SYNC_DUMMY3_DONE 0xcafe0003  // dummy execution complete
+
+// ibex -> CVA6: written to CHESHIRE_SCRATCH_11
+#define SYNC_IBEX_READY3 0x5a1e0003  // snooper configured, start dummy
 
 int main(void) {
-    
-    extern char dummy1_code_start, dummy1_code_end, dummy2_code_start, dummy2_code_end, dummy3_code_start, dummy3_code_end;
+    extern char dummy_code_start, dummy_code_end;
 
-    int base, last, new_last, PC_DST_H, PC_DST_L, PC_SRC_L, PC_SRC_H, CTR_TYPE;
+    car_init_start();
+    LOG("[hostd] snooper_stress_test: start\n\r");
 
-    //--------------------------------------------------------------------------------------------//
-    //-----------------------------------ADDR MODE STRESS TEST------------------------------------//
-    //--------------------------------------------------------------------------------------------//
+    // Publish dummy code region addresses via scratch registers
+    // scratch 8-9: region addresses, scratch 10: CVA6->ibex sync, scratch 11: ibex->CVA6 sync
+    *reg32(&__base_regs, CHESHIRE_SCRATCH_8_REG_OFFSET)  = (uintptr_t)&dummy_code_start;
+    *reg32(&__base_regs, CHESHIRE_SCRATCH_9_REG_OFFSET)  = (uintptr_t)&dummy_code_end;
+    fence();
+    // Sentinel: signal ibex that addresses are valid and snooper can be configured
+    *reg32(&__base_regs, CHESHIRE_SCRATCH_10_REG_OFFSET) = SYNC_ADDR_VALID;
+    fence();
 
     // Enable security island
     car_enable_domain(CAR_SECURITY_RST);
 
-    // enable watermark interrupt for security island
-    car_irq_router_enable(58, IRQ_ROUTER_TARGET_SECURITY_ISLAND);
-    // enable trigger interrupt for security island
-    car_irq_router_enable(59, IRQ_ROUTER_TARGET_SECURITY_ISLAND);
-
-    // Configure LSBs and MSBs of START_ADDRESS for RANGE_0, first logging region
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_0_BASE_H_REG_OFFSET) = 0x00000000;
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_0_BASE_L_REG_OFFSET) = (uintptr_t)&dummy1_code_start;
-
-    // Configure LSBs and MSBs of END_ADDRESS for RANGE_0, first logging region
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_0_LAST_H_REG_OFFSET) = 0x00000000;
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_0_LAST_L_REG_OFFSET) = (uintptr_t)&dummy1_code_end;
-
-    // Configure LSBs and MSBs of START_ADDRESS for RANGE_1, second logging region
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_1_BASE_H_REG_OFFSET) = 0x00000000;
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_1_BASE_L_REG_OFFSET) = (uintptr_t)&dummy2_code_start;
-
-    // Configure LSBs and MSBs of END_ADDRESS for RANGE_1, second logging region
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_1_LAST_H_REG_OFFSET) = 0x00000000;
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_1_LAST_L_REG_OFFSET) = (uintptr_t)&dummy2_code_end;
-
-    // Configure LSBs and MSBs of START_ADDRESS for RANGE_2, third logging region
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_2_BASE_H_REG_OFFSET) = 0x00000000;
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_2_BASE_L_REG_OFFSET) = (uintptr_t)&dummy3_code_start;
-
-    // Configure LSBs and MSBs of END_ADDRESS for RANGE_2, third logging region
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_2_LAST_H_REG_OFFSET) = 0x00000000;
-    *reg32(&__base_snprcfg, CFG_REGS_RANGE_2_LAST_L_REG_OFFSET) = (uintptr_t)&dummy3_code_end;
+    //------------------------------------------------------------------------//
+    //--------------------------- DUMMY3 CODE REGION -------------------------//
+    // ibex monitors RANGE_2; CVA6 intentionally overflows the snooper buffer //
+    // past HALT_LEVEL, causing repeated snooper-induced core halts.  ibex    //
+    // concurrently drains the buffer to release each halt.                   //
+    //                                                                         //
+    // Performance counters:                                                   //
+    //   mcycle          – total wall-clock cycles (includes snooper halts)   //
+    //   mhpmcounter3    – pipeline stall cycles (CVA6 event 22)              //
+    //------------------------------------------------------------------------//
+    // Wait for ibex to finish configuring the snooper
+    while (*reg32(&__base_regs, CHESHIRE_SCRATCH_11_REG_OFFSET) != SYNC_IBEX_READY3)
+        ;
+    // Configure mhpmevent3 = 22 (Pipeline Stall: cycles stalled in read-operands stage)
+    asm volatile("csrwi mhpmevent3, 22" ::: "memory");
+    // Reset mhpmcounter3 to zero before the measured region
+    asm volatile("csrwi mhpmcounter3, 0" ::: "memory");
+    uint64_t dummy_cycle_start = get_mcycle();
 
 
-    // Configure Snooper to log only instructions executed in M mode
-    set_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_M_MODE_BIT);
+    asm volatile ("dummy_code_start:");
+    *reg32(&__base_regs, CHESHIRE_SCRATCH_0_REG_OFFSET) = 0;
+    for (volatile int i = 0; i < 2000; i++) {
+        //if (*reg32(&__base_regs, CHESHIRE_SCRATCH_0_REG_OFFSET) != 0)
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+        *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
+    }
+    asm volatile ("dummy_code_end:");
 
-    // Configure Snooper Logging mode: Addr
-    // Addr mode to log PC src, PC dst and ctr_type of branches and jumps
-    clear_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_TRACE_MODE_OFFSET);
+    uint64_t dummy_cycle_end = get_mcycle();
+    uint64_t dummy_stall_cycles;
+    asm volatile("csrr %0, mhpmcounter3" : "=r"(dummy_stall_cycles) :: "memory");
 
-    // Set core halting level, core is halted if more than 800 unread address elements are present (or more than 4000 instruction elements)
-    *reg32(&__base_snprcfg, CFG_REGS_HALT_LEVEL_REG_OFFSET) = 0x00003E80;
-    // Enable core halting
-    set_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_CORE_HALT_EN_BIT);
-
-
-    //------------------------------------WATERMARK INTERRUPT--------------------------------------//
-    // This interrupt triggers when the numbers of elements stored in the buffer minus
-    // the number of elements previously read through AXI is higher than the watermark level
-    // The interrupt is high as long as this condition is met and does not stop the snooper operation
-    // In instruction mode each element containts a single 32bit field (the instruction opcode)
-    // thus the watermark level is increased by 1 for every element logged in instruction mode
-    // In address mode each element is composed by 5 32bit fields (PC_SRC_L, PC_SRC_H, PC_DST_L, PC_DST_H, CTR_TYPE)
-    // thus the watermark level is increased by 5 for every element logged in address mode
-
-    // Set watermark level to 10 instructions (instruction mode) or 2 instruction addresses (address mode)
-    *reg32(&__base_snprcfg, CFG_REGS_WATERMARK_LEVEL_REG_OFFSET) = 0x0000000a; 
-    // Enable watermark interrupt
-    set_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_WATERMARK_EN_BIT);
-
-
-    // Enable RANGE_0 from CTRL register, this will enable the snooper to log RANGE_0
-    set_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_PC_RANGE_0_BIT);
-
-    // Enable RANGE_1 from CTRL register, this will enable the snooper to log RANGE_1
-    set_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_PC_RANGE_1_BIT);
-
-    // Enable RANGE_2 from CTRL register, this will enable the snooper to log RANGE_2
-    set_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_PC_RANGE_2_BIT);
+    LOG("[hostd] dummy perf: total_cycles=%lu pipeline_stall_cycles=%lu\n\r",
+           (unsigned long)(dummy_cycle_end - dummy_cycle_start),
+           (unsigned long)dummy_stall_cycles);
+    LOG("[hostd] dummy perf: stall_ratio=%.2f%%\n\r",
+           (double)dummy_stall_cycles / (dummy_cycle_end - dummy_cycle_start) * 100);
 
     fence();
+    *reg32(&__base_regs, CHESHIRE_SCRATCH_10_REG_OFFSET) = SYNC_DUMMY3_DONE;
+    fence();
 
-    asm volatile ("dummy1_code_start:");
-
-    *reg32(&__base_regs, CHESHIRE_SCRATCH_0_REG_OFFSET) = 0;
-    for (int i=0; i<300; i++) {
-        if (*reg32(&__base_regs, CHESHIRE_SCRATCH_0_REG_OFFSET) != 0)
-            *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
-    }
-
-    asm volatile ("dummy1_code_end:");
-
-    // Base is the index of the first valid element (it is incremented starting from 0 only when the buffer starts overwriting itself)
-    base = *reg32(&__base_snprcfg, CFG_REGS_BASE_REG_OFFSET);
-    // In address mode, last is the index of the last valid element + 20 (if no elements are valid this returns zero, if 1 element is valid this returns 20)
-    last = *reg32(&__base_snprcfg, CFG_REGS_LAST_REG_OFFSET);
-
-    for (int i=base;i<last;i=i+20) {
-        PC_SRC_L = *reg32(&__base_snpr, i + 0x00);
-        PC_SRC_H = *reg32(&__base_snpr, i + 0x04);
-        PC_DST_L = *reg32(&__base_snpr, i + 0x08);
-        PC_DST_H = *reg32(&__base_snpr, i + 0x0C);
-        CTR_TYPE = *reg32(&__base_snpr, i + 0x10);
-        if ((PC_SRC_L <= (uintptr_t)&dummy1_code_start) || (PC_SRC_L >= (uintptr_t)&dummy1_code_end))
-            return 1; // return error in case the buffer contains a PC outside of the logging region
-    }
-
-    asm volatile ("dummy2_code_start:");
-
-    *reg32(&__base_regs, CHESHIRE_SCRATCH_0_REG_OFFSET) = 0;
-    for (int i=0; i<300; i++) {
-        if (*reg32(&__base_regs, CHESHIRE_SCRATCH_0_REG_OFFSET) != 0)
-            *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
-    }
-
-    asm volatile ("dummy2_code_end:");
-
-    // In address mode, last is the index of the last valid element + 20 (if no elements are valid this returns zero, if 1 element is valid this returns 20)
-    new_last = *reg32(&__base_snprcfg, CFG_REGS_LAST_REG_OFFSET);
-
-    if (new_last > last) { // Snooper didn't recirculate since last read
-        for (int i=last;i<new_last;i=i+20) { // Keep reading normally
-            PC_SRC_L = *reg32(&__base_snpr, i + 0x00);
-            PC_SRC_H = *reg32(&__base_snpr, i + 0x04);
-            PC_DST_L = *reg32(&__base_snpr, i + 0x08);
-            PC_DST_H = *reg32(&__base_snpr, i + 0x0C);
-            CTR_TYPE = *reg32(&__base_snpr, i + 0x10);
-            if ((PC_SRC_L <= (uintptr_t)&dummy2_code_start) || (PC_SRC_L >= (uintptr_t)&dummy2_code_end))
-                return 1; // return error in case the buffer contains a PC outside of the logging region
-        }
-    } else { // Snooper recirculated since last read
-        // Keep reading the buffer until the end...
-        for (int i=last;i<16380;i=i+20) {
-            PC_SRC_L = *reg32(&__base_snpr, i + 0x00);
-            PC_SRC_H = *reg32(&__base_snpr, i + 0x04);
-            PC_DST_L = *reg32(&__base_snpr, i + 0x08);
-            PC_DST_H = *reg32(&__base_snpr, i + 0x0C);
-            CTR_TYPE = *reg32(&__base_snpr, i + 0x10);
-            if ((PC_SRC_L <= (uintptr_t)&dummy2_code_start) || (PC_SRC_L >= (uintptr_t)&dummy2_code_end))
-                return 1; // return error in case the buffer contains a PC outside of the logging region
-        }
-        for (int i=0;i<new_last;i=i+20) { // ...and then start again from the beginning
-            PC_SRC_L = *reg32(&__base_snpr, i + 0x00);
-            PC_SRC_H = *reg32(&__base_snpr, i + 0x04);
-            PC_DST_L = *reg32(&__base_snpr, i + 0x08);
-            PC_DST_H = *reg32(&__base_snpr, i + 0x0C);
-            CTR_TYPE = *reg32(&__base_snpr, i + 0x10);
-            if ((PC_SRC_L <= (uintptr_t)&dummy2_code_start) || (PC_SRC_L >= (uintptr_t)&dummy2_code_end))
-                return 1; // return error in case the buffer contains a PC outside of the logging region
-        }
-    }
-
-    asm volatile ("dummy3_code_start:");
-
-    *reg32(&__base_regs, CHESHIRE_SCRATCH_0_REG_OFFSET) = 0;
-    for (int i=0; i<3; i++) {
-        if (*reg32(&__base_regs, CHESHIRE_SCRATCH_0_REG_OFFSET) != 0)
-            *reg32(&__base_regs, CHESHIRE_SCRATCH_1_REG_OFFSET) = 1;
-    }
-
-    asm volatile ("dummy3_code_end:");
-
-    last = new_last;
-    // In address mode, last is the index of the last valid element + 20 (if no elements are valid this returns zero, if 1 element is valid this returns 20)
-    new_last = *reg32(&__base_snprcfg, CFG_REGS_LAST_REG_OFFSET);
-
-    if (new_last > last) { // Snooper didn't recirculate since last read
-        for (int i=last;i<new_last;i=i+20) { // Keep reading normally
-            PC_SRC_L = *reg32(&__base_snpr, i + 0x00);
-            PC_SRC_H = *reg32(&__base_snpr, i + 0x04);
-            PC_DST_L = *reg32(&__base_snpr, i + 0x08);
-            PC_DST_H = *reg32(&__base_snpr, i + 0x0C);
-            CTR_TYPE = *reg32(&__base_snpr, i + 0x10);
-            if ((PC_SRC_L <= (uintptr_t)&dummy3_code_start) || (PC_SRC_L >= (uintptr_t)&dummy3_code_end))
-                return 1; // return error in case the buffer contains a PC outside of the logging region
-        }
-    } else { // Snooper recirculated since last read
-        // Keep reading the buffer until the end...
-        for (int i=last;i<16380;i=i+20) {
-            PC_SRC_L = *reg32(&__base_snpr, i + 0x00);
-            PC_SRC_H = *reg32(&__base_snpr, i + 0x04);
-            PC_DST_L = *reg32(&__base_snpr, i + 0x08);
-            PC_DST_H = *reg32(&__base_snpr, i + 0x0C);
-            CTR_TYPE = *reg32(&__base_snpr, i + 0x10);
-            if ((PC_SRC_L <= (uintptr_t)&dummy3_code_start) || (PC_SRC_L >= (uintptr_t)&dummy3_code_end))
-                return 1; // return error in case the buffer contains a PC outside of the logging region
-        }
-        for (int i=0;i<new_last;i=i+20) { // ...and then start again from the beginning
-            PC_SRC_L = *reg32(&__base_snpr, i + 0x00);
-            PC_SRC_H = *reg32(&__base_snpr, i + 0x04);
-            PC_DST_L = *reg32(&__base_snpr, i + 0x08);
-            PC_DST_H = *reg32(&__base_snpr, i + 0x0C);
-            CTR_TYPE = *reg32(&__base_snpr, i + 0x10);
-            if ((PC_SRC_L <= (uintptr_t)&dummy3_code_start) || (PC_SRC_L >= (uintptr_t)&dummy3_code_end))
-                return 1; // return error in case the buffer contains a PC outside of the logging region
-        }
-    }
-
-    // Reset circular buffer
-    set_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_CNT_RST_BIT);
-    clear_register_bit(&__base_snprcfg, CFG_REGS_CTRL_REG_OFFSET,CFG_REGS_CTRL_CNT_RST_BIT);
-
+    LOG("[hostd] snooper_stress_test: done\n\r");
     return 0;
 }
-

--- a/sw/tests/bare-metal/secd/sw.mk
+++ b/sw/tests/bare-metal/secd/sw.mk
@@ -10,33 +10,45 @@
 
 # List all the directories in the 'tests' folder
 CAR_SECD_SW := $(CAR_SW_DIR)/tests/bare-metal/secd
+CAR_SECD_PULPD_SW := $(CAR_SW_DIR)/tests/bare-metal/secd/pulpd
 SECD_SW_DIR := $(SECD_ROOT)/sw/tests
+SECD_SCARV_SW_DIR := $(SECD_ROOT)/sw/tests/scarv
 SECD_PULPD_SW_DIR := $(SECD_SW_DIR)/regression_tests/opentitan-cluster
-SECD_PULPD_TEST_DIRS := $(filter-out %/deeploy,$(wildcard $(SECD_SW_DIR)/regression_tests/opentitan-cluster/*))
 
-# Generate the list of build targets based on the directories
-SECD_PULPD_BUILD_TARGETS := $(addsuffix /build,$(SECD_PULPD_TEST_DIRS))
+SCARV_TESTS := \
+	cluster_offload \
+	idma_test
 
-# We have a target per test. The target (1) compiles the binary and (2) generates the needed stimuli
-# file format, if any is required.
-$(SECD_PULPD_SW_DIR)/%/build: $(SECD_ROOT)
-	# Compile
-	$(MAKE) -C $(SECD_PULPD_SW_DIR)/$* all io=host_uart
-	$(MAKE) -C $(SECD_PULPD_SW_DIR)/$* dis > $(CAR_SECD_SW)/$*.dump
-	cp $@/test/test $(CAR_SECD_SW)/$*.elf
-	@echo $(SECD_PULPD_SW_DIR)
+PULP_TEST_DIRS    := $(filter-out %deeploy/ %neureka/, $(wildcard $(SECD_PULPD_SW_DIR)/*/))
+NEUREKA_TEST_DIRS := $(wildcard $(SECD_PULPD_SW_DIR)/neureka/*/)
+DEEPLOY_TEST_DIRS := $(wildcard $(SECD_PULPD_SW_DIR)/deeploy/*/*/)
 
-CLUSTER_OFFLOAD = $(SECD_SW_DIR)/cluster_offload/cluster_offload.elf
+ALL_PULPD_TEST_DIRS := $(PULP_TEST_DIRS) $(NEUREKA_TEST_DIRS) $(DEEPLOY_TEST_DIRS)
 
-$(SECD_SW_DIR)/cluster_offload/cluster_offload.elf:
-	$(MAKE) -C $(patsubst %/,%,$(dir $@)) clean all
-	cp $(patsubst %/,%,$(dir $@))/cluster_offload.elf $(CAR_SECD_SW)/
-	cp $(patsubst %/,%,$(dir $@))/cluster_offload.dis $(CAR_SECD_SW)/
+.PHONY: secd-pulpd-sw-build secd-pulpd-sw-clean ot-sw-build ot-sw-clean secd-sw-all secd-sw-clean
+
+secd-pulpd-sw-build:
+	mkdir -p $(CAR_SECD_PULPD_SW)
+	$(foreach test, $(PULP_TEST_DIRS),    $(MAKE) -C $(test) all io=host_uart;)
+	$(foreach test, $(NEUREKA_TEST_DIRS), $(MAKE) -C $(test) all MODE=1 io=host_uart;)
+	$(foreach test, $(DEEPLOY_TEST_DIRS), $(MAKE) -C $(test) pulp_nn all io=host_uart;)
+	$(foreach test, $(ALL_PULPD_TEST_DIRS), cp $(test)/build/test/test $(CAR_SECD_PULPD_SW)/$(notdir $(test:%/=%)).elf;)
+
+secd-pulpd-sw-clean:
+	$(foreach test, $(ALL_PULPD_TEST_DIRS), $(MAKE) -C $(test) clean;)
+
+ot-sw-build:
+	$(foreach test, $(SCARV_TESTS), $(MAKE) -C $(SECD_ROOT) compile-bazel-sram target=scarv test_name=$(test) defines=NO_STANDALONE=1;)
+	$(foreach test, $(SCARV_TESTS), install -m 755 $(SECD_SCARV_SW_DIR)/$(test)/bazel-out/$(test).elf $(CAR_SECD_SW)/$(test).elf;)
+
+ot-sw-clean:
+	$(foreach test, $(SCARV_TESTS), $(MAKE) -C $(SECD_ROOT) clean-sram target=scarv test_name=$(test);)
 
 # Global targets
-secd-sw-all: $(SECD_PULPD_BUILD_TARGETS) $(CLUSTER_OFFLOAD)
+secd-sw-all: secd-pulpd-sw-build ot-sw-build
 
 secd-sw-clean:
 	# Clean all the directories in 'tests'
+	rm -f $(CAR_SECD_SW)/*.elf  $(CAR_SECD_PULPD_SW)/*.elf
 	. $(CAR_ROOT)/env/secd-env.sh; \
-	$(foreach dir, $(SECD_PULPD_TEST_DIRS), $(MAKE) -C $(dir) clean;)
+	$(MAKE) secd-pulpd-sw-clean ot-sw-clean

--- a/sw/tests/bare-metal/secd/sw.mk
+++ b/sw/tests/bare-metal/secd/sw.mk
@@ -19,7 +19,8 @@ SCARV_TESTS := \
 	cluster_offload \
 	idma_test \
 	mbox_host \
-	mbox_wu_cluster
+	mbox_wu_cluster \
+	snooper_stress_test 
 
 PULP_TEST_DIRS    := $(filter-out %deeploy/ %neureka/, $(wildcard $(SECD_PULPD_SW_DIR)/*/))
 NEUREKA_TEST_DIRS := $(wildcard $(SECD_PULPD_SW_DIR)/neureka/*/)
@@ -40,7 +41,7 @@ secd-pulpd-sw-clean:
 	$(foreach test, $(ALL_PULPD_TEST_DIRS), $(MAKE) -C $(test) clean;)
 
 ot-sw-build:
-	$(foreach test, $(SCARV_TESTS), $(MAKE) -C $(SECD_ROOT) compile-bazel-sram target=scarv test_name=$(test) defines=NO_STANDALONE=1;)
+	$(foreach test, $(SCARV_TESTS), CHS_ROOT=$(CHS_ROOT) $(MAKE) -C $(SECD_ROOT) compile-bazel-sram target=scarv test_name=$(test) defines=NO_STANDALONE=1;)
 	$(foreach test, $(SCARV_TESTS), install -m 755 $(SECD_SCARV_SW_DIR)/$(test)/bazel-out/$(test).elf $(CAR_SECD_SW)/$(test).elf;)
 
 ot-sw-clean:

--- a/sw/tests/bare-metal/secd/sw.mk
+++ b/sw/tests/bare-metal/secd/sw.mk
@@ -17,7 +17,9 @@ SECD_PULPD_SW_DIR := $(SECD_SW_DIR)/regression_tests/opentitan-cluster
 
 SCARV_TESTS := \
 	cluster_offload \
-	idma_test
+	idma_test \
+	mbox_host \
+	mbox_wu_cluster
 
 PULP_TEST_DIRS    := $(filter-out %deeploy/ %neureka/, $(wildcard $(SECD_PULPD_SW_DIR)/*/))
 NEUREKA_TEST_DIRS := $(wildcard $(SECD_PULPD_SW_DIR)/neureka/*/)

--- a/target/sim/src/astral_tb.sv
+++ b/target/sim/src/astral_tb.sv
@@ -73,6 +73,8 @@ module tb_astral;
   logic car_phy_sel_valid;
   logic car_phy_sel;
 
+  logic secd_start;
+
   // timing format for $display("...$t..", $realtime)
   initial begin : timing_format
     $timeformat(-9, 0, "ns", 9);
@@ -88,6 +90,8 @@ module tb_astral;
     if (!$value$plusargs("CHS_IMAGE=%s",    chs_boot_hex))    chs_boot_hex    = "";
     if (!$value$plusargs("CHS_MEM_RAND=%d", chs_mem_rand))    chs_mem_rand    = 0;
     car_phy_sel_valid = $value$plusargs("CAR_PHY_SEL=%d", car_phy_sel);
+
+    secd_start = 1'b0;
 
     if (car_phy_sel_valid) begin
       $display("[TB] PHY %0d selected and enabled, all other PHYs forced to high-Z", car_phy_sel);
@@ -173,6 +177,7 @@ module tb_astral;
             end
             $display("[TB] %t - Loading '%s' through JTAG", $realtime, chs_preload_elf);
             fix.chs_vip.jtag_elf_run(chs_preload_elf);
+            secd_start = 1'b1;
             fix.chs_vip.jtag_wait_for_eoc(exit_code);
           end 1: begin  // Standalone Serial Link passive preload
             $display("[TB] %t - Loading '%s' through SLINK", $realtime, chs_preload_elf);
@@ -217,6 +222,7 @@ module tb_astral;
       $finish;
     end else begin
       $display("[TB] %t - Cheshire not executing no binary provided", $realtime);
+      secd_start = 1'b1;
     end
   end
 
@@ -316,13 +322,17 @@ module tb_astral;
         // Wait for FLL lock
         fix.wait_fll_lock(bypass_pll);
 
+        wait (secd_start == 1'b1);
+        repeat(1000)
+          @(posedge fix.ref_clk);
+
         // Initialize JTAG at first
         fix.chs_vip.jtag_init();
 
         // Writing max burst length in Hyperbus configuration registers to
         // prevent the Verification IPs from triggering timing checks.
-        $display("[TB] INFO: Configuring Hyperbus through JTAG.");
-        fix.chs_vip.jtag_write_reg32(HyperbusTburstMax, 32'd128, 1);
+        //$display("[TB] INFO: Configuring Hyperbus through JTAG.");
+        //fix.chs_vip.jtag_write_reg32(HyperbusTburstMax, 32'd128, 1);
 
         case(secd_boot_mode)
           0: begin

--- a/target/sim/src/astral_tb.sv
+++ b/target/sim/src/astral_tb.sv
@@ -329,11 +329,6 @@ module tb_astral;
         // Initialize JTAG at first
         fix.chs_vip.jtag_init();
 
-        // Writing max burst length in Hyperbus configuration registers to
-        // prevent the Verification IPs from triggering timing checks.
-        //$display("[TB] INFO: Configuring Hyperbus through JTAG.");
-        //fix.chs_vip.jtag_write_reg32(HyperbusTburstMax, 32'd128, 1);
-
         case(secd_boot_mode)
           0: begin
             // Wait before security island HW is initialized


### PR DESCRIPTION
This PR:

- Improves SECD SW compile flow by restoring building OpenTitan tests with Bazel and partially restoring incremental compilation of tests
- Fixes the testbench to enable testing of concurrent Cheshire-Security Island tests
- Adds Cheshire-Security Island mailbox test (also using dedicated PLIC library for Cheshire)
- Adds Snooper Stress Test
- Bumps dependencies
- Extends CI to include all the latest tests